### PR TITLE
Setup Pyenv with Ansible

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -3,7 +3,6 @@
 
 # TODO
 
-- `pyenv`
 - `zet` -- installation
 - `neovim`
 - other programs from the list

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+interpreter_python = /usr/bin/python3

--- a/ansible/roles/bash/tasks/main.yaml
+++ b/ansible/roles/bash/tasks/main.yaml
@@ -17,11 +17,9 @@
         src: templates/bashrc.j2
         dest: "{{ bash_default_dir }}/.bashrc"
         mode: u=+rwx,g=+r-wx,o=+r-wx
-      changed_when: false
 
     - name: Ensure Bash profile file is present
       copy:
         src: files/profile
         dest: "{{ bash_default_dir }}/.profile"
         mode: u=+rwx,g=+r-wx,o=+r-wx
-      changed_when: false

--- a/ansible/roles/bash/tasks/main.yaml
+++ b/ansible/roles/bash/tasks/main.yaml
@@ -8,6 +8,10 @@
       include_tasks: macos.yaml
       when: ansible_distribution == "MacOSX"
 
+    - name: Check if Pyenv is installed
+      shell: "command -v pyenv"
+      register: pyenv_exists
+
     - name: Ensure Bash configuration file is present
       template:
         src: templates/bashrc.j2

--- a/ansible/roles/bash/templates/bashrc.j2
+++ b/ansible/roles/bash/templates/bashrc.j2
@@ -165,6 +165,7 @@ nvm() {
 	[ -s "$NVM_DIR/bash_completion" ] && . "$NVM_DIR/bash_completion"
 	nvm "$@"
 }
+{% if pyenv_exists.rc == 0 %}
 
 
 # PYENV ================================================== #
@@ -172,3 +173,4 @@ export PYENV_ROOT="$HOME/.pyenv"
 command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"
 eval "$(pyenv init -)"
 export PYENV_VIRTUALENV_DISABLE_PROMPT=1
+{% endif %}

--- a/ansible/roles/bash/templates/bashrc.j2
+++ b/ansible/roles/bash/templates/bashrc.j2
@@ -124,11 +124,12 @@ alias \
 
 
 # COMPLETIONS ============================================ #
-
+{% if ansible_distribution == "MacOSX" %}
 # OSX doesn't have Bash completions installed by default.
 shopt -q progcomp && [ -r "/usr/local/etc/profile.d/bash_completion.sh" ] && \
 	source "/usr/local/etc/profile.d/bash_completion.sh"
 
+{% endif %}
 __exists() { type "$1" &>/dev/null; }
 
 __exists gh && source <(gh completion -s bash)

--- a/ansible/roles/pyenv/tasks/macos.yaml
+++ b/ansible/roles/pyenv/tasks/macos.yaml
@@ -1,0 +1,13 @@
+---
+
+- name: Install Pyenv with Homebrew
+  homebrew:
+    name:
+      - pyenv
+    state: present
+
+- name: Install Pyenv-virtualenv with Homebrew
+  homebrew:
+    name:
+      - pyenv-virtualenv
+    state: present

--- a/ansible/roles/pyenv/tasks/main.yaml
+++ b/ansible/roles/pyenv/tasks/main.yaml
@@ -1,0 +1,15 @@
+---
+
+- name: Install Pyenv
+  tags: pyenv
+  become_user: "{{ user }}"
+  block:
+    - name: Install Pyenv on MacOS with Homebrew
+      import_tasks: macos.yaml
+      when: ansible_distribution == "MacOSX"
+
+    - name: Make sure Pyenv root directory exists
+      file:
+        path: "{{ pyenv_root_dir }}"
+        state: directory
+        mode: u=+rwx,g=+r-wx,o=+r-wx

--- a/ansible/roles/pyenv/vars/main/main.yaml
+++ b/ansible/roles/pyenv/vars/main/main.yaml
@@ -1,0 +1,3 @@
+user: "$USER"
+home: "$HOME"
+pyenv_root_dir: "{{ home }}/.pyenv"

--- a/ansible/setup.yaml
+++ b/ansible/setup.yaml
@@ -1,4 +1,5 @@
 ---
+
 - hosts: hosts
   roles:
     - git
@@ -9,3 +10,4 @@
     - nvm
     - lynx
     - bash
+    - pyenv

--- a/ansible/setup.yaml
+++ b/ansible/setup.yaml
@@ -9,5 +9,5 @@
     - go
     - nvm
     - lynx
-    - bash
     - pyenv
+    - bash


### PR DESCRIPTION
- Added pynev to the Ansible setup file
- Added Ansible config with default Python
- Parametrized bashrc based on Pyenv existing
- Removed changed_when from bash task
- Based shell completion on dist being MacOS
- Defined the main task for pyenv Ansible install
- Added Homebrew Pyenv install for MacOS
- Defined Pyenv task-specific variables in Ansible
- Placed Pyenv before Bash in Ansible setup play
