### PR TITLE
Add ff command to the exec Ansible task

### DIFF
--- a/ansible/roles/exec/files/ff
+++ b/ansible/roles/exec/files/ff
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+"${EDITOR:-vim}" -O $(fzf $@)


### PR DESCRIPTION
This command uses fzf fuzzy finder to open a file in the editor that defaults to vim.
