### PR TITLE
Use Wezterm instead of the default terminal

### DIFF
--- a/ansible/roles/wezterm/files/wezterm.lua
+++ b/ansible/roles/wezterm/files/wezterm.lua
@@ -1,0 +1,28 @@
+--  _    _ _____ ___________ ______________  ___
+-- | |  | |  ___|___  /_   _|  ___| ___ \  \/  |
+-- | |  | | |__    / /  | | | |__ | |_/ / .  . |
+-- | |/\| |  __|  / /   | | |  __||    /| |\/| |
+-- \  /\  / |___./ /___ | | | |___| |\ \| |  | |
+--  \/  \/\____/\_____/ \_/ \____/\_| \_\_|  |_/
+--
+
+
+local wezterm = require("wezterm")
+
+
+---------------- CONFIGURATION ------------------
+local config = wezterm.config_builder()
+config.color_scheme = "GruvboxDarkHard"
+config.font = wezterm.font("Hack Nerd Font")
+config.font_size = 14.0
+config.keys = {
+	{
+		key = "f",
+		mods = "SHIFT|CTRL",
+		action = wezterm.action.ToggleFullScreen,
+	},
+}
+config.enable_tab_bar = false
+-------------------------------------------------
+
+return config

--- a/ansible/roles/wezterm/tasks/macos.yaml
+++ b/ansible/roles/wezterm/tasks/macos.yaml
@@ -1,0 +1,8 @@
+---
+- name: Install Wezterm with Homebrew Cask
+  homebrew_cask:
+    name:
+      - wezterm
+    state: present
+    upgrade_all: false
+...

--- a/ansible/roles/wezterm/tasks/main.yaml
+++ b/ansible/roles/wezterm/tasks/main.yaml
@@ -1,0 +1,21 @@
+---
+- name: Install Wezterm
+  tags: wezterm
+  become_user: "{{ user }}"
+  block:
+    - name: Install Wezterm on MacOS
+      include_tasks: macos.yaml
+      when: ansible_distribution == "MacOSX"
+
+    - name: Ensure that Wezterm configuration directory is present
+      file:
+        path: "{{ wezterm_config_dir }}"
+        state: directory
+        mode: u=+rwx,g=+r-wx,o=+r-wx
+
+    - name: Ensure Wezterm configuration files are present
+      copy:
+        src: files/
+        dest: "{{ wezterm_config_dir }}/"
+        mode: u=+rw,g=+r-wx,o=+r-wx
+...

--- a/ansible/roles/wezterm/vars/main/main.yaml
+++ b/ansible/roles/wezterm/vars/main/main.yaml
@@ -1,0 +1,3 @@
+user: "$USER"
+home: "$HOME"
+wezterm_config_dir: "{{ home }}/.config/wezterm"

--- a/ansible/setup.yaml
+++ b/ansible/setup.yaml
@@ -37,4 +37,5 @@
     - k9s
     - firefox
     - karabiner
+    - wezterm
 ...


### PR DESCRIPTION
- **Added wezterm tag to the Ansible setup**
- **Created Wezterm role for Ansible**
- **Added basic configuration for Wezterm**

I found the lua based config for wezterm way better compared to the functionality of native
terminals available right of the box on Debian and MacOS. 
